### PR TITLE
Make it easier to construct worker ops.

### DIFF
--- a/nix-remote/src/worker_op.rs
+++ b/nix-remote/src/worker_op.rs
@@ -12,7 +12,7 @@ use crate::{
 
 /// A zero-sized marker type. Its job is to mark the expected response
 /// type for each worker op.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]
 pub struct Resp<T> {
     #[serde(skip)]

--- a/nix-remote/src/worker_op.rs
+++ b/nix-remote/src/worker_op.rs
@@ -25,6 +25,14 @@ impl<T> Resp<T> {
     }
 }
 
+impl<T> Default for Resp<T> {
+    fn default() -> Self {
+        Self {
+            marker: std::marker::PhantomData,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]
 pub struct Plain<T>(pub T);
@@ -40,6 +48,12 @@ impl<T> Deref for Plain<T> {
 impl<T> DerefMut for Plain<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
+    }
+}
+
+impl<T> From<T> for Plain<T> {
+    fn from(value: T) -> Self {
+        Plain(value)
     }
 }
 


### PR DESCRIPTION
Our existing examples were reading worker ops from someone else. Turns out we never put much thought into how to actually construct them instead of reading them off the wire...