### PR TITLE
proto: use version 35

### DIFF
--- a/nix-remote/src/lib.rs
+++ b/nix-remote/src/lib.rs
@@ -150,7 +150,7 @@ const WORKER_MAGIC_1: u64 = 0x6e697863;
 const WORKER_MAGIC_2: u64 = 0x6478696f;
 const PROTOCOL_VERSION: DaemonVersion = DaemonVersion {
     major: 1,
-    minor: 34,
+    minor: 35,
 };
 
 /// A wrapper around a `std::io::Read`, adding support for the nix wire format.

--- a/nix-remote/src/nix_client.rs
+++ b/nix-remote/src/nix_client.rs
@@ -55,6 +55,7 @@ impl<R: Read, W: Write> NixDaemonClient<R, W> {
             "Proxy daemon is: {}",
             String::from_utf8_lossy(proxy_daemon_version.0.as_ref())
         );
+        let _trusted_flag: u64 = self.rx_from_daemon.inner.read_nix()?;
         loop {
             let err_msg = self.read_error_msg().unwrap();
             if err_msg == Msg::Last(()) {

--- a/nix-remote/src/nix_client.rs
+++ b/nix-remote/src/nix_client.rs
@@ -113,6 +113,10 @@ impl<R: Read, W: Write> NixDaemonClient<R, W> {
     pub fn reader(&mut self) -> &mut R {
         &mut self.rx_from_daemon.inner
     }
+
+    pub fn writer(&mut self) -> &mut W {
+        &mut self.tx_to_daemon.inner
+    }
 }
 
 impl<R: BufRead, W: Write> NixDaemonClient<R, W> {

--- a/nix-remote/src/nix_daemon_proxy.rs
+++ b/nix-remote/src/nix_daemon_proxy.rs
@@ -44,8 +44,11 @@ impl<R: Read, W: Write> NixDaemonProxy<R, W> {
 
         let _obsolete_cpu_affinity = self.rx_from_client.read_u64()?;
         let _obsolete_reserve_space = self.rx_from_client.read_u64()?;
+        // Version
         self.tx_to_client
             .write_string("rust-nix-bazel-0.1.0".as_bytes())?;
+        // Trusted flag. FIXME(jadel): configurability?
+        self.tx_to_client.write_u64(1)?;
         self.tx_to_client.flush()?;
 
         self.tx_to_client.write_nix(&stderr::Msg::Last(()))?;


### PR DESCRIPTION
As mentioned on https://github.com/tweag/nix-remote-rust/issues/3#issuecomment-3099533776

I've not tested the server side of this but the client side works.